### PR TITLE
Removed model types for general teacher

### DIFF
--- a/pymodelextractor/teachers/general_teacher.py
+++ b/pymodelextractor/teachers/general_teacher.py
@@ -12,7 +12,7 @@ from pythautomata.model_comparators.mealy_machine_comparison_strategy import Mea
 from pythautomata.model_comparators.moore_machine_comparison_strategy import MooreMachineComparisonStrategy as MooreComparator
 
 class GeneralTeacher(Teacher):
-    def __init__(self, state_machine: Union[Automaton, MM, Mealys],
+    def __init__(self, state_machine,
                 comparison_strategy: Union[FAComparator, PAC, MealyComparator, MooreComparator],
                 w_cache = True):
         self._state_machine = state_machine


### PR DESCRIPTION
Removed model types.
This way we can use GeneralTeacher with RNN and not only with our automata definitions.