### PR TITLE
Observation Pack Fix

### DIFF
--- a/pymodelextractor/learners/counterexample_processing/rivest_schapire.py
+++ b/pymodelextractor/learners/counterexample_processing/rivest_schapire.py
@@ -13,10 +13,7 @@ class RivestSchapire:
         upper = len(counterexample) - 2
         while True:
             mid = (lower + upper) // 2
-            if counterexample[:mid] == ():
-                 end_state = self.get_end_state(hypothesis, Sequence())
-            else:
-                end_state = self.get_end_state(hypothesis, Sequence(counterexample[:mid]))
+            end_state = self.get_end_state(hypothesis, counterexample[:mid])
             prefix = end_state.name
             sec_half_counterexample = Sequence(counterexample[mid:])
             mq = target.membership_query(prefix + sec_half_counterexample)
@@ -31,7 +28,6 @@ class RivestSchapire:
                 
     def get_end_state(self, hypothesis: DFA, sequence: Sequence) -> State:
         actual_state = hypothesis.initial_state
-        if sequence != Sequence():
-            for symbol in sequence:
-                actual_state = actual_state.next_state_for(symbol)
+        for symbol in sequence:
+            actual_state = actual_state.next_state_for(symbol)
         return actual_state

--- a/pymodelextractor/learners/observation_tree_learners/observation_pack_learner.py
+++ b/pymodelextractor/learners/observation_tree_learners/observation_pack_learner.py
@@ -7,6 +7,8 @@ from pymodelextractor.learners.observation_table_learners.observation_table impo
 from pymodelextractor.learners.learning_result import LearningResult
 from pymodelextractor.learners.counterexample_processing.rivest_schapire import RivestSchapire
 from pythautomata.model_exporters.dot_exporters.dfa_dot_exporting_strategy import DfaDotExportingStrategy
+# import Symbol
+from pythautomata.base_types.symbol import Symbol
 
 class ObservationPackLearner(Learner):
     def __init__(self):
@@ -85,10 +87,11 @@ class ObservationPackLearner(Learner):
 
             state.transitions[symbol] = {self.link_node_t_state[tgt]}
 
-            self.outgoing[state].add((state, symbol))
+            self.outgoing[state].add((self.link_node_t_state[tgt], symbol))
             self.incoming[self.link_node_t_state[tgt]].add((state, symbol))
 
         states = list(self.link_state_t_node.keys())
+                            
         return DFA(self._alphabet, hypothesis.initial_state, 
                         set(states), None)
     
@@ -103,17 +106,13 @@ class ObservationPackLearner(Learner):
         v = self.cex_analyzer.process_counterexample(counterexample, 
                                                      hypothesis, self._teacher)
         u = Sequence(counterexample[:len(counterexample) - len(v) - 1])
-        a = Sequence([counterexample[len(counterexample) - len(v) - 1]])
+        a = counterexample[len(counterexample) - len(v) - 1]
         return (u,a,v)
     
-    def split(self, u: Sequence, a: Sequence, v: Sequence, hypothesis: DFA):
-        if(u == Sequence()): 
-            ua = a
-        else:
-            ua = u + a
-
-        q_old = self.cex_analyzer.get_end_state(hypothesis, ua)
-        q_new = self.create_single_state(ua, q_old.is_final)
+    def split(self, u: Sequence, a: Symbol, v: Sequence, hypothesis: DFA):
+        q_pred = self.cex_analyzer.get_end_state(hypothesis, u)
+        q_old = q_pred.next_state_for(a)
+        q_new = self.create_single_state(q_pred.name+a, q_old.is_final)
         self.split_leaf(q_old, q_new, v)
         self.reset_closed_transitions(q_old)
 
@@ -148,7 +147,7 @@ class ObservationPackLearner(Learner):
                 )
         self.incoming[state] = set()
         self.outgoing[state] = set()
-
+        
     def create_single_state(self, name: Sequence, is_final: bool) -> State: 
         new_state = State(name=name, is_final=is_final)
         self.outgoing[new_state] = set()
@@ -162,7 +161,6 @@ class ClassificationTree():
         self._teacher = teacher
         self.root = root
         self._mq_cache = {}
-        self._sift_cache = {}
 
     def _ask_membership_query(self, sequence: Sequence) -> bool:
         if sequence in self._mq_cache:

--- a/pymodelextractor/tests/learners_tests/test_observation_pack_learner.py
+++ b/pymodelextractor/tests/learners_tests/test_observation_pack_learner.py
@@ -9,6 +9,8 @@ from pythautomata.automata.deterministic_finite_automaton import \
 from pythautomata.automata_definitions.tomitas_grammars import TomitasGrammars
 from pythautomata.model_comparators.hopcroft_karp_comparison_strategy import \
     HopcroftKarpComparisonStrategy as ComparisonStrategy
+from pythautomata.model_comparators.random_walk_comparison_strategy import \
+    RandomWalkComparisonStrategy as RWComparisonStrategy
 from pythautomata.automata_definitions.bollig_habermehl_kern_leucker_automata import BolligHabermehlKernLeuckerAutomata
 from pythautomata.automata_definitions.omlin_giles_automata import OmlinGilesAutomata
 from pythautomata.utilities.nicaud_dfa_generator import generate_dfa
@@ -16,8 +18,9 @@ from pythautomata.base_types.symbol import SymbolStr
 from pythautomata.base_types.alphabet import Alphabet
 from pymodelextractor.teachers.pac_comparison_strategy import PACComparisonStrategy
 from pymodelextractor.teachers.general_teacher import GeneralTeacher
+from pythautomata.base_types.state import State
+from pythautomata.base_types.symbol import SymbolStr
 from itertools import chain
-
 
 class TestObservationPackLearner(unittest.TestCase):
     def setUp(self):
@@ -26,6 +29,9 @@ class TestObservationPackLearner(unittest.TestCase):
     def teacher(self, automaton: DeterministicFiniteAutomaton) -> AutomatonTeacher:
         return AutomatonTeacher(automaton, ComparisonStrategy())
 
+    def teacher_rw(self, automaton: DeterministicFiniteAutomaton) -> AutomatonTeacher:
+        return AutomatonTeacher(automaton, RWComparisonStrategy(number_steps=10000, reset_probability=0.01))
+        
     def test_tomitas_1(self):
         grammar1 = TomitasGrammars.get_automaton_1()
         teacher = self.teacher(grammar1)
@@ -73,12 +79,11 @@ class TestObservationPackLearner(unittest.TestCase):
             result = self.learner.learn(teacher)
             assert ComparisonStrategy().are_equivalent(
                 result.model, automaton)
-      
+    
     def test_with_100_states_automaton(self):
         dfa = generate_dfa(alphabet= Alphabet(frozenset(map(SymbolStr, ["0", "1", "2"]))), nominal_size=100, seed=17)
         teacher = self.teacher(dfa)
         result = self.learner.learn(teacher)
-        print(result.info["equivalence_queries_count"])
         assert ComparisonStrategy().are_equivalent(
             result.model, dfa)
     
@@ -86,6 +91,14 @@ class TestObservationPackLearner(unittest.TestCase):
         dfa = generate_dfa(alphabet= Alphabet(frozenset(map(SymbolStr, ["0", "1"]))), nominal_size=10, seed=17)
         teacher = GeneralTeacher(dfa, 
                                  PACComparisonStrategy(dfa.alphabet, 0.005, 0.005, 20))
+        result = self.learner.learn(teacher)
+        assert ComparisonStrategy().are_equivalent(
+            result.model, dfa)
+        
+    def test_with_random_walk(self):
+        dfa = generate_dfa(alphabet= Alphabet(frozenset(map(SymbolStr, ["0", "1"]))), 
+                           nominal_size=50, seed=17)
+        teacher = self.teacher_rw(dfa)
         result = self.learner.learn(teacher)
         assert ComparisonStrategy().are_equivalent(
             result.model, dfa)


### PR DESCRIPTION
Observation Pack algorithm was not working correctly with Random Walk oracle. It had 3 possible results:

The hypothesis was equivalent to the target DFA.
The hypothesis was equivalent to the target DFA but it has more states.
A counterexample was never fixed in the hypothesis

In the refinement, the new state was created concatenating u+a but the correct thing is to concatenate q_pred.name+a